### PR TITLE
Parallel wow/root loading & fix endianness handling.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,4 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace = true

--- a/src/libtactmon/libtactmon/io/FileStream.cpp
+++ b/src/libtactmon/libtactmon/io/FileStream.cpp
@@ -1,8 +1,8 @@
 #include "libtactmon/io/FileStream.hpp"
 
 namespace libtactmon::io {
-    FileStream::FileStream(std::filesystem::path filePath, std::endian fileEndianness)
-        : IStream(fileEndianness)
+    FileStream::FileStream(std::filesystem::path filePath)
+        : IStream()
     {
         try {
             _stream.open(filePath.string());

--- a/src/libtactmon/libtactmon/io/FileStream.hpp
+++ b/src/libtactmon/libtactmon/io/FileStream.hpp
@@ -8,7 +8,7 @@
 
 namespace libtactmon::io {
     struct FileStream final : IReadableStream {
-        FileStream(std::filesystem::path filePath, std::endian fileEndianness);
+        explicit FileStream(std::filesystem::path filePath);
 
     public: // IStream
         size_t GetLength() const override;

--- a/src/libtactmon/libtactmon/io/IStream.hpp
+++ b/src/libtactmon/libtactmon/io/IStream.hpp
@@ -22,9 +22,8 @@ namespace libtactmon::io {
      * Encapsulates a sequence of bytes.
      */
     struct IStream {
-        explicit IStream(std::endian endianness = std::endian::native) : _endianness(endianness) { }
-
-        std::endian GetEndianness() const { return _endianness; }
+        explicit IStream() { }
+        virtual ~IStream() = default;
 
         /**
          * Returns the length of this stream.
@@ -35,9 +34,6 @@ namespace libtactmon::io {
          * Determines if this stream was successfully opened.
          */
         virtual operator bool() const = 0;
-
-    private:
-        std::endian _endianness;
     };
 
 }

--- a/src/libtactmon/libtactmon/io/IWritableStream.hpp
+++ b/src/libtactmon/libtactmon/io/IWritableStream.hpp
@@ -8,7 +8,7 @@ namespace libtactmon::io {
      * Provides write operations on a sequence of bytes.
      */
     struct IWritableStream : virtual IStream {
-        explicit IWritableStream(std::endian endianness = std::endian::native) : IStream(endianness) { }
+        explicit IWritableStream() { }
         virtual ~IWritableStream() = default;
 
         /**
@@ -35,10 +35,10 @@ namespace libtactmon::io {
          * Writes a value to the stream, with the given endianness.
          * 
          * @param[in] value      The value to write to the stream.
-         * @param[in] endianness The endianness to use.
+         * @param[in] endianness The endianness to use. By default, the native endianness is used.
          */
         template <typename T> requires (utility::is_span_v<T> || std::is_trivial_v<T>)
-        size_t Write(T const value, std::endian endianness) {
+        size_t Write(T const value, std::endian endianness = std::endian::native) {
             if constexpr (utility::is_span_v<T>) {
                 return _WriteSpan(std::as_bytes(value), endianness, sizeof(T));
             } else {
@@ -48,13 +48,13 @@ namespace libtactmon::io {
         }
 
         size_t WriteString(std::string_view value) {
-            return Write(std::span { value }, GetEndianness());
+            return Write(std::span { value });
         }
 
         size_t WriteCString(std::string_view value) {
             size_t bytesWritten = WriteString(value);
             if (bytesWritten == value.length())
-                bytesWritten += Write(uint8_t(0), GetEndianness());
+                bytesWritten += Write(uint8_t(0));
             return bytesWritten;
         }
 
@@ -66,7 +66,7 @@ namespace libtactmon::io {
         size_t _WriteSpan(std::span<const T> valueSpan, std::endian endianness, size_t elementSize) {
             std::span<std::byte> writtenBytes = _WriteImpl(std::as_bytes(valueSpan));
 
-            if (endianness != GetEndianness()) {
+            if (endianness != std::endian::native) {
                 auto begin = writtenBytes.begin();
                 auto end = writtenBytes.end();
 

--- a/src/libtactmon/libtactmon/io/MemoryStream.cpp
+++ b/src/libtactmon/libtactmon/io/MemoryStream.cpp
@@ -1,6 +1,8 @@
 #include "libtactmon/io/MemoryStream.hpp"
 
 namespace libtactmon::io {
+    SpanStream::SpanStream(std::span<const std::byte> data) : _data(data) { }
+
     size_t SpanStream::_ReadImpl(std::span<std::byte> bytes) {
         size_t length = std::min(bytes.size(), _data.size() - _cursor);
 

--- a/src/libtactmon/libtactmon/io/MemoryStream.cpp
+++ b/src/libtactmon/libtactmon/io/MemoryStream.cpp
@@ -1,8 +1,16 @@
 #include "libtactmon/io/MemoryStream.hpp"
 
 namespace libtactmon::io {
-    MemoryStream::MemoryStream(std::span<std::byte> data, std::endian endianness)
-        : IReadableStream(endianness), _data(data)
+    size_t SpanStream::_ReadImpl(std::span<std::byte> bytes) {
+        size_t length = std::min(bytes.size(), _data.size() - _cursor);
+
+        std::copy_n(Data().subspan(length).data(), length, bytes.data());
+        _cursor += length;
+        return length;
+    }
+
+    MemoryStream::MemoryStream(std::span<std::byte> data)
+        : IReadableStream(), _data(data)
     { }
 
     size_t MemoryStream::SeekRead(size_t offset) {
@@ -21,10 +29,10 @@ namespace libtactmon::io {
 
     // ^^^ MemoryStream / GrowableMemoryStream vvv
 
-    GrowableMemoryStream::GrowableMemoryStream(std::endian endianness) : IReadableStream(endianness), IWritableStream(endianness) { }
+    GrowableMemoryStream::GrowableMemoryStream() : IReadableStream(), IWritableStream() { }
 
-    GrowableMemoryStream::GrowableMemoryStream(std::span<std::byte> data, std::endian endianness)
-        : IReadableStream(endianness), IWritableStream(endianness), _data(data.begin(), data.end())
+    GrowableMemoryStream::GrowableMemoryStream(std::span<std::byte> data)
+        : IReadableStream(), IWritableStream(), _data(data.begin(), data.end())
     { }
 
     size_t GrowableMemoryStream::SeekRead(size_t offset) {

--- a/src/libtactmon/libtactmon/io/MemoryStream.hpp
+++ b/src/libtactmon/libtactmon/io/MemoryStream.hpp
@@ -17,7 +17,9 @@
 
 namespace libtactmon::io {
     struct SpanStream final : IReadableStream {
-        explicit SpanStream(std::span<const uint8_t> data);
+        explicit SpanStream(std::span<const std::byte> data);
+
+        using IReadableStream::Data;
 
     public: // IReadableStream
         size_t GetReadCursor() const override { return _cursor; }
@@ -28,13 +30,13 @@ namespace libtactmon::io {
 
         operator bool() const override { return true; }
 
-        std::span<std::byte const> Data() const override { return std::as_bytes(_data.subspan(_cursor)); }
+        std::span<std::byte const> Data() const override { return _data.subspan(_cursor); }
 
     protected:
         size_t _ReadImpl(std::span<std::byte> writableSpan) override;
 
     private:
-        std::span<const uint8_t> _data;
+        std::span<const std::byte> _data;
         size_t _cursor = 0;
     };
 
@@ -68,7 +70,7 @@ namespace libtactmon::io {
 
         template <typename ConstBufferSequence>
         requires boost::asio::is_const_buffer_sequence<ConstBufferSequence>::value
-        GrowableMemoryStream(ConstBufferSequence const& buffers) : GrowableMemoryStream(endianness) {
+        GrowableMemoryStream(ConstBufferSequence const& buffers) : GrowableMemoryStream() {
             _data.reserve(boost::asio::buffer_size(buffers));
             for (auto const buffer : boost::beast::buffers_range_ref(buffers))
                 _data.insert(_data.end(), reinterpret_cast<const std::byte*>(buffer.data()), reinterpret_cast<const std::byte*>(buffer.data()) + buffer.size());

--- a/src/libtactmon/libtactmon/net/MemoryDownloadTask.cpp
+++ b/src/libtactmon/libtactmon/net/MemoryDownloadTask.cpp
@@ -9,6 +9,6 @@ namespace libtactmon::net {
         if (message.result() != boost::beast::http::status::ok)
             return std::nullopt;
 
-        return io::GrowableMemoryStream { message.body().data(), std::endian::little };
+        return io::GrowableMemoryStream { message.body().data() };
     }
 }

--- a/src/libtactmon/libtactmon/tact/BLTE.hpp
+++ b/src/libtactmon/libtactmon/tact/BLTE.hpp
@@ -47,6 +47,6 @@ namespace libtactmon::tact {
         io::IReadableStream& GetStream() { return _dataBuffer; }
 
     private:
-        io::GrowableMemoryStream _dataBuffer { std::endian::little };
+        io::GrowableMemoryStream _dataBuffer;
     };
 }

--- a/src/libtactmon/libtactmon/tact/Cache.cpp
+++ b/src/libtactmon/libtactmon/tact/Cache.cpp
@@ -11,7 +11,7 @@ namespace libtactmon::tact {
         if (!std::filesystem::is_directory(absolutePath.parent_path()))
             std::filesystem::create_directories(absolutePath.parent_path());
 
-        return io::FileStream { absolutePath, std::endian::little };
+        return io::FileStream { absolutePath };
     }
 
     std::filesystem::path Cache::GetAbsolutePath(std::string_view relativePath) const { 

--- a/src/libtactmon/libtactmon/tact/Cache.hpp
+++ b/src/libtactmon/libtactmon/tact/Cache.hpp
@@ -25,7 +25,7 @@ namespace libtactmon::tact {
                 return std::nullopt;
 
             try {
-                io::FileStream fstream{ fullResourcePath, std::endian::little };
+                io::FileStream fstream { fullResourcePath };
                 return handler(fstream);
             } catch (std::exception const& ex) {
                 // TODO: possibly log this

--- a/src/libtactmon/libtactmon/tact/data/Index.cpp
+++ b/src/libtactmon/libtactmon/tact/data/Index.cpp
@@ -83,6 +83,7 @@ namespace libtactmon::tact::data {
                 std::span<const uint8_t> keyData = stream.Data<uint8_t>().subspan(0, _keySizeBytes);
                 stream.SkipRead(_keySizeBytes);
 
+                // If the key is all 0s, that's an end marker
                 if (std::ranges::all_of(keyData, [](uint8_t b){ return b == 0; }))
                     continue;
 

--- a/src/libtactmon/libtactmon/tact/data/product/Product.hpp
+++ b/src/libtactmon/libtactmon/tact/data/product/Product.hpp
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string_view>

--- a/src/libtactmon/libtactmon/tact/data/product/Utility.hpp
+++ b/src/libtactmon/libtactmon/tact/data/product/Utility.hpp
@@ -47,15 +47,15 @@ namespace libtactmon::tact::data::product {
         }
 
         /**
-        * Resolves a data file.
-        * 
-        * @param[in] cdns   A list of available CDNs, as provided by Ribbit.
-        * @param[in] key    The configuration file's key.
-        * @param[in] parser A callable in charge of parsing the file.
-        * @param[in] logger A logger for errors that occur during download.
-        * 
-        * @returns The parsed file or an empty optional if unable to.
-        */
+         * Resolves a data file.
+         * 
+         * @param[in] cdns   A list of available CDNs, as provided by Ribbit.
+         * @param[in] key    The configuration file's key.
+         * @param[in] parser A callable in charge of parsing the file.
+         * @param[in] logger A logger for errors that occur during download.
+         * 
+         * @returns The parsed file or an empty optional if unable to.
+         */
         template <typename T>
         std::optional<T> ResolveData(ribbit::types::CDNs const& cdns,
             std::string_view key, Parser<T> parser, std::shared_ptr<spdlog::logger> logger = nullptr) const

--- a/src/libtactmon/libtactmon/tact/data/product/wow/Product.cpp
+++ b/src/libtactmon/libtactmon/tact/data/product/wow/Product.cpp
@@ -3,6 +3,10 @@
 
 #include <fstream>
 
+#include <fmt/chrono.h>
+
+#include <spdlog/stopwatch.h>
+
 namespace libtactmon::tact::data::product::wow {
     bool Product::Load(std::string_view buildConfig, std::string_view cdnConfig) noexcept {
         if (!tact::data::product::Product::Load(buildConfig, cdnConfig))
@@ -11,6 +15,8 @@ namespace libtactmon::tact::data::product::wow {
         std::optional<tact::data::FileLocation> rootLocation = Base::FindFile(_buildConfig->Root);
         if (!rootLocation)
             return false;
+
+        spdlog::stopwatch sw;
 
         _root = [&]() -> std::optional<tact::data::product::wow::Root> {
             for (size_t i = 0; i < rootLocation->keyCount(); ++i) {
@@ -34,7 +40,9 @@ namespace libtactmon::tact::data::product::wow {
             return false;
 
         if (_logger != nullptr)
-            _logger->info("({}) {} entries found in root manifest.", _buildConfig->BuildName, _root->size());
+            _logger->info("({}) Root manifest loaded in {:.3} seconds ({} entries).", _buildConfig->BuildName,
+                sw,
+                _root->size());
         return true;
     }
 

--- a/src/libtactmon/libtactmon/tact/data/product/wow/Product.cpp
+++ b/src/libtactmon/libtactmon/tact/data/product/wow/Product.cpp
@@ -19,7 +19,7 @@ namespace libtactmon::tact::data::product::wow {
                 auto root = Base::ResolveCachedData<tact::data::product::wow::Root>(key.ToString(), [&encoding = _encoding](io::IReadableStream& fstream) -> std::optional<tact::data::product::wow::Root> {
                     std::optional<tact::BLTE> blte = tact::BLTE::Parse(fstream);
                     if (blte.has_value())
-                        return tact::data::product::wow::Root { blte->GetStream(), encoding->GetContentKeySize() };
+                        return tact::data::product::wow::Root::Parse(blte->GetStream(), encoding->GetContentKeySize());
 
                     return std::nullopt;
                 });

--- a/src/libtactmon/libtactmon/tact/data/product/wow/Root.cpp
+++ b/src/libtactmon/libtactmon/tact/data/product/wow/Root.cpp
@@ -1,8 +1,125 @@
 #include "libtactmon/crypto/Jenkins.hpp"
 #include "libtactmon/tact/data/product/wow/Root.hpp"
+#include "libtactmon/utility/Endian.hpp"
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <boost/thread/future.hpp>
 
 namespace libtactmon::tact::data::product::wow {
-    Root::Root(io::IReadableStream& stream, size_t contentKeySize) {
+    struct PageInfo {
+        uint32_t numRecords;
+        ContentFlags contentFlags;
+        LocaleFlags localeFlags;
+
+        std::optional<std::span<const uint8_t>> data;
+        size_t offset;
+        size_t length;
+    };
+
+    std::optional<Root::Block> ParseBlock(PageInfo const& pageInfo) {
+        Root::Block block;
+        block.Content = pageInfo.contentFlags;
+        block.Locales = pageInfo.localeFlags;
+
+        block.entries.reserve(pageInfo.numRecords);
+
+        // Get some stream here, around the span
+        io::SpanStream stream { pageInfo.data }; // ...
+
+        std::span<uint32_t const> fileDataIDs = stream.Data<uint32_t>().subspan(0, pageInfo.numRecords);
+        stream.SkipRead(pageInfo.numRecords * sizeof(uint32_t));
+
+        for (size_t i = 0; i < numRecords; ++i) {
+            fileDataID += utility::to_endianness<std::endian::little>(fileDataIDs[i]) + 1;
+
+            std::span<const uint8_t> hashSpan = stream.Data<uint8_t>().subspan(0, contentKeySize);
+            stream.SkipRead(contentKeySize);
+
+            uint64_t nameHash = stream.Read<uint64_t>(std::endian::little); // Jenkins96 of the file's path
+
+            _entries.emplace_back(tact::CKey{ hashSpan }, fileDataID, nameHash);
+        }
+    }
+
+    /* static */ std::optional<Root> Root::Parse(io::IReadableStream& stream, size_t contentKeySize) {
+        if (!stream.CanRead(sizeof(uint32_t)))
+            return std::nullopt;
+
+        uint32_t magic = stream.Read<uint32_t>(std::endian::little);
+
+        bool interleave = true;
+        bool canSkip = false;
+
+        if (magic == 0x4D465354) {
+            if (!stream.CanRead(sizeof(uint32_t) * 2))
+                return std::nullopt;
+
+            uint32_t totalFileCount = stream.Read<uint32_t>(std::endian::little);
+            uint32_t namedFileCount = stream.Read<uint32_t>(std::endian::little);
+
+            interleave = false;
+            canSkip = totalFileCount != namedFileCount;
+        }
+
+        // Generate segments of data to parse in parallel
+        boost::asio::thread_pool pool { 4 };
+
+        std::list<std::future<std::optional<Block>>> futures;
+
+        while (stream.GetReadCursor() < stream.GetLength()) {
+            if (!stream.CanRead(12))
+                return std::nullopt;
+
+            PageInfo page;
+            page.numRecords = stream.Read<uint32_t>(std::endian::little);
+            page.contentFlags = static_cast<ContentFlags>(stream.Read<uint32_t>(std::endian::little));
+            page.localeFlags = static_cast<LocaleFlags>(stream.Read<uint32_t>(std::endian::little));
+
+            page.offset = stream.GetReadCursor();
+
+            size_t length = sizeof(uint32_t) * page.numRecords; // u32 fileDataID[numRecords]
+            if (interleave) {
+                length += contentKeySize * page.numRecords; // u8 contentKeys[contentKeySize][numRecords]
+                length += sizeof(uint64_t) * page.numRecords; // u64 nameHash[numRecords]
+            }
+            else {
+                if (!canSkip || (static_cast<uint32_t>(contentFlags) & static_cast<uint32_t>(ContentFlags::NoNameHash)) == 0) {
+                    length += sizeof(uint64_t) * page.numRecords; // u64 nameHash[numRecords]
+                }
+            }
+
+            if (!stream.CanRead(page.length))
+                return std::nullopt;
+
+            page.data.emplace(stream.Data<uint8_t>().subspan(0, length));
+            stream.SkipRead(page.length);
+
+            auto blockLoader = std::make_shared<boost::packaged_task<std::optional<Block>>>([pageInfo = std::move(page)]() {
+                return ParseBlock(pageInfo);
+            });
+
+            futures.push_back(blockLoader.get_future());
+            boost::asio::post(pool, [blockLoader]() { (*blockLoader)(); });
+        }
+
+        Root instance;
+
+        instance._blocks.reserve(futures.size());
+        for (auto&& future : boost::when_all(futures.begin(), futures.end()).get()) {
+            std::optional<Block> value = future.get();
+            if (!value.has_value())
+                return std::nullopt;
+
+            instance._blocks.emplace_back(std::move(*value));
+        }
+
+        pool.join();
+
+        return instance;
+    }
+
+    /*Root::Root(io::IReadableStream& stream, size_t contentKeySize) {
         uint32_t magic = stream.Read<uint32_t>(std::endian::little);
 
         bool interleave = true;
@@ -24,46 +141,71 @@ namespace libtactmon::tact::data::product::wow {
             ContentFlags contentFlags = static_cast<ContentFlags>(stream.Read<uint32_t>(std::endian::little));
             LocaleFlags localeFlags = static_cast<LocaleFlags>(stream.Read<uint32_t>(std::endian::little));
 
-            std::vector<uint32_t> fileDataIDs;
-            fileDataIDs.resize(numRecords);
-            stream.Read(std::span{ fileDataIDs }, std::endian::little);
-
-            int32_t deltaBase = -1;
-            for (uint32_t& sectionFDID : fileDataIDs) {
-                sectionFDID += deltaBase + 1;
-                deltaBase = sectionFDID;
+            if (!stream.CanRead(numRecords * sizeof(uint32_t))) {
+                _entries.clear();
+                return;
             }
 
+            std::span<uint32_t const> fileDataIDs = stream.Data<uint32_t>().subspan(0, numRecords);
+            stream.SkipRead(numRecords * sizeof(uint32_t));
+
+            _entries.reserve(_entries.size() + numRecords);
+
             if (interleave) {
+                if (!stream.CanRead((contentKeySize + sizeof(uint64_t)) * numRecords)) {
+                    _entries.clear();
+                    return;
+                }
+
+                uint32_t fileDataID = -1;
                 for (size_t i = 0; i < numRecords; ++i) {
+                    fileDataID += utility::to_endianness<std::endian::little>(fileDataIDs[i]) + 1;
+
                     std::span<const uint8_t> hashSpan = stream.Data<uint8_t>().subspan(0, contentKeySize);
                     stream.SkipRead(contentKeySize);
 
                     uint64_t nameHash = stream.Read<uint64_t>(std::endian::little); // Jenkins96 of the file's path
 
-                    _entries.emplace_back(tact::CKey { hashSpan }, fileDataIDs[i], nameHash);
+                    _entries.emplace_back(tact::CKey{ hashSpan }, fileDataID, nameHash);
                 }
             }
             else {
                 // Read the file's data hashes in one pass.
+                if (!stream.CanRead(numRecords * contentKeySize)) {
+                    _entries.clear();
+                    return;
+                }
+
                 std::span<const uint8_t> hashSpan = stream.Data<uint8_t>().subspan(0, numRecords * contentKeySize);
                 stream.SkipRead(hashSpan.size());
 
+                uint32_t fileDataID = -1;
+
                 if (!canSkip || (static_cast<uint32_t>(contentFlags) & static_cast<uint32_t>(ContentFlags::NoNameHash)) == 0) {
+                    if (!stream.CanRead(numRecords * sizeof(uint64_t))) {
+                        _entries.clear();
+                        return;
+                    }
+
                     for (size_t i = 0; i < numRecords; ++i) {
+                        fileDataID += utility::to_endianness<std::endian::little>(fileDataIDs[i]) + 1;
+
                         uint64_t nameHash = stream.Read<uint64_t>(std::endian::little); // Jenkins96 of the file's path
 
-                        _entries.emplace_back(tact::CKey { hashSpan.subspan(i * contentKeySize, contentKeySize) }, fileDataIDs[i], nameHash);
+                        _entries.emplace_back(tact::CKey{ hashSpan.subspan(i * contentKeySize, contentKeySize) }, fileDataID, nameHash);
                     }
                 }
                 else {
-                    for (size_t i = 0; i < numRecords; ++i)
-                        _entries.emplace_back(tact::CKey { hashSpan.subspan(i * contentKeySize, contentKeySize) }, fileDataIDs[i], 0);
+                    for (size_t i = 0; i < numRecords; ++i) {
+                        fileDataID += utility::to_endianness<std::endian::little>(fileDataIDs[i]) + 1;
+                        _entries.emplace_back(tact::CKey{ hashSpan.subspan(i * contentKeySize, contentKeySize) }, fileDataID, 0);
+                    }
                 }
             }
         }
     }
 
+    */
     Root::Root(Root&& other) noexcept : _entries(std::move(other._entries)) {
 
     }
@@ -90,15 +232,21 @@ namespace libtactmon::tact::data::product::wow {
     }
 
     std::optional<tact::CKey> Root::FindFile(uint32_t fileDataID) const {
-        for (Entry const& entry : _entries)
-            if (entry.FileDataID == fileDataID)
-                return entry.ContentKey;
+        // Can a bonary search be used on the blocks as well? This assumes blocks don't overlap and max(prev_block.fdids) < min(curr_block.fdids)
+        for (Block const& block : _blocks) {
+            // Can use binary search because we know fdids are ordered.
+            auto itr = std::lower_bound(block.entries.begin(), block.entries.end(), fileDataID, [](Entry const& entry, uint32_t fdid) { return entry.FileDataID < fdid; });
+            if (itr != block.entries.end())
+                return itr->ContentKey;
+        }
 
         return std::nullopt;
     }
 
     std::optional<tact::CKey> Root::FindFile(std::string_view fileName) const {
         uint32_t jenkinsHash = crypto::JenkinsHash(fileName);
+
+        // Unfortunately, no binary search here.
         for (Entry const& entry : _entries)
             if (entry.NameHash == jenkinsHash)
                 return entry.ContentKey;

--- a/src/libtactmon/libtactmon/tact/data/product/wow/Root.hpp
+++ b/src/libtactmon/libtactmon/tact/data/product/wow/Root.hpp
@@ -53,7 +53,7 @@ namespace libtactmon::tact::data::product::wow {
         static std::optional<Root> Parse(io::IReadableStream& stream, size_t contentKeySize);
 
     private:
-        Root();
+        Root() = default;
 
     public:
         Root(Root&& other) noexcept;
@@ -63,7 +63,7 @@ namespace libtactmon::tact::data::product::wow {
         std::optional<tact::CKey> FindFile(uint32_t fileDataID) const;
         std::optional<tact::CKey> FindFile(std::string_view fileName) const;
 
-        size_t size() const { return _entries.size(); }
+        size_t size() const;
 
         struct Entry {
             tact::CKey ContentKey;
@@ -83,6 +83,14 @@ namespace libtactmon::tact::data::product::wow {
             LocaleFlags Locales;
 
             std::vector<Entry> entries;
+
+            Block() = default;
+
+            Block(Block&& other) noexcept = default;
+            Block& operator = (Block&& other) noexcept = default;
+
+            Block(Block const&) = delete;
+            Block& operator = (Block const&) = delete;
         };
 
     private:

--- a/src/libtactmon/libtactmon/tact/data/product/wow/Root.hpp
+++ b/src/libtactmon/libtactmon/tact/data/product/wow/Root.hpp
@@ -50,7 +50,12 @@ namespace libtactmon::tact::data::product::wow {
             ptPT = 0x00010000,
         };
 
-        Root(io::IReadableStream& stream, size_t contentKeySize);
+        static std::optional<Root> Parse(io::IReadableStream& stream, size_t contentKeySize);
+
+    private:
+        Root();
+
+    public:
         Root(Root&& other) noexcept;
 
         Root& operator = (Root&& other) noexcept;
@@ -73,7 +78,14 @@ namespace libtactmon::tact::data::product::wow {
             Entry(tact::CKey contentKey, uint32_t fileDataID, uint64_t nameHash) : ContentKey(contentKey), FileDataID(fileDataID), NameHash(nameHash) { }
         };
 
+        struct Block {
+            ContentFlags Content;
+            LocaleFlags Locales;
+
+            std::vector<Entry> entries;
+        };
+
     private:
-        std::vector<Entry> _entries;
+        std::vector<Block> _blocks;
     };
 }

--- a/src/libtactmon/libtactmon/utility/Endian.hpp
+++ b/src/libtactmon/libtactmon/utility/Endian.hpp
@@ -30,4 +30,17 @@ namespace libtactmon::utility {
         return utility::bit_cast<T>(value_representation);
     }
 #endif
+
+    template <std::integral T>
+    constexpr T to_endianness(T value, std::endian from, std::endian to) {
+        return (from == to) ? value : byteswap(value);
+    }
+
+    template <std::endian To, std::endian From = std::endian::native, typename T>
+    constexpr T to_endianness(T value) {
+        if constexpr (From == To)
+            return value;
+
+        return byteswap(value);
+    }
 }

--- a/src/tactmon/backend/Product.cpp
+++ b/src/tactmon/backend/Product.cpp
@@ -26,11 +26,15 @@ namespace backend {
             _currentBuild = entity;
 
             if (!_loading.exchange(true)) {
-                if (!_product->Load(db::get<db::entity::build::build_config>(entity), db::get<db::entity::build::cdn_config>(entity)))
+                if (!_product->Load(db::get<db::entity::build::build_config>(entity), db::get<db::entity::build::cdn_config>(entity))) {
+                    _loading.exchange(false);
+
                     return false;
+                }
             }
         }
 
+        _loading.exchange(false);
         return true;
     }
 }

--- a/src/tactmon/backend/ProductCache.cpp
+++ b/src/tactmon/backend/ProductCache.cpp
@@ -1,5 +1,7 @@
 #include "backend/ProductCache.hpp"
 
+#include <functional>
+
 #include <boost/range/adaptor/map.hpp>
 
 using namespace std::chrono_literals;
@@ -17,6 +19,7 @@ namespace backend {
             bool expiredEntry = record->expirationTimer <= std::chrono::high_resolution_clock::now();
             if (expiredEntry && record->product.IsLoading()) {
                 // Expired but loading? Your internet is bad, let's be nice and keep the instance active
+                // TODO: Probably a code smell, should not belong here.
                 record->expirationTimer += 1min;
                 return false;
             }

--- a/src/tactmon/beast/BlockTableEncodedStreamTransform.cpp
+++ b/src/tactmon/beast/BlockTableEncodedStreamTransform.cpp
@@ -6,11 +6,11 @@
 
 namespace boost::beast::user {
     BlockTableEncodedStreamTransform::BlockTableEncodedStreamTransform(OutputHandler handler, InputFeedback feedback) 
-        : _handler(handler), _feedback(feedback), _ms(std::endian::little)
+        : _handler(handler), _feedback(feedback), _ms()
     { }
 
     std::size_t BlockTableEncodedStreamTransform::Parse(uint8_t const* data, size_t size, boost::beast::error_code& ec) {
-        _ms.Write(std::span { data, size }, std::endian::little);
+        _ms.Write(std::span { data, size });
         _feedback(size);
 
         for (;;) {

--- a/src/tactmon/utility/Logging.cpp
+++ b/src/tactmon/utility/Logging.cpp
@@ -47,10 +47,6 @@ namespace utility::logging {
     template <typename T>
     struct Manager final : private ManagerBase {
         explicit Manager(std::function<std::shared_ptr<T>(std::string, spdlog::sinks_init_list)> factory) : ManagerBase(), _factory(factory) { 
-            if constexpr (!std::is_same_v<T, spdlog::async_logger>)
-                _consoleSink->set_pattern("[%Y-%d-%m %H:%M:%S %z] [%n] [%^%l%$] [thread %t] %v");
-            else
-                _consoleSink->set_pattern("[%Y-%d-%m %H:%M:%S %z] [%n] [%^%l%$] [thread %t] %v");
         }
 
         std::shared_ptr<T> operator [] (std::string_view name) {


### PR DESCRIPTION
Rewrite stream readers to use native endianness and convert on the fly. This doesn't apply to IReadableStream::Data<T>(), which will return native-endian data. To counteract that, provide `utility::to_endianness<To, From>(T)`. This should also fix parsers on big-endian systems.

Also make root loading parallel. There's no real benefit to this, but I could. Parallel index loading runs into some form of thread contention and stalls my PC, for now.